### PR TITLE
add support for +srv mongodb uris.

### DIFF
--- a/origami/cli/utils.py
+++ b/origami/cli/utils.py
@@ -82,7 +82,7 @@ def load_data(source: str, data_config: DataConfig) -> pd.DataFrame:
     Returns:
     - pandas.DataFrame: The loaded data as a DataFrame.
     """
-    if source.startswith("mongodb://"):
+    if source.startswith("mongodb://") or source.startswith("mongodb+srv://"):
         # load data from MongoDB, project out _id field by default
         projection = {"_id": 0} | OmegaConf.to_object(data_config.projection)
         df = load_df_from_mongodb(


### PR DESCRIPTION
That's all that was needed. There aren't any tests for `load_data()` as it would require mocking out the MongoDB driver, but I tested it manually through the CLI: 

```
> origami train "mongodb+srv://rueckstiess:<password>@cluster0.2vjwbli.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0" -d sample_mflix -c movies -e plot,cast,poster,title,fullplot,directors,lastupdated,tomatoes.lastUpdated,writers

|  step: 0  |  epoch: 0  |  batch_num: 0  |  batch_dt: 0.00  |  batch_loss: 4.3189  |  lr: 1.01e-06  |
|  step: 1  |  epoch: 0  |  batch_num: 10  |  batch_dt: 926.89  |  batch_loss: 4.3099  |  lr: 1.10e-05  |
|  step: 2  |  epoch: 0  |  batch_num: 20  |  batch_dt: 941.08  |  batch_loss: 4.2411  |  lr: 2.10e-05  |
|  step: 3  |  epoch: 0  |  batch_num: 30  |  batch_dt: 918.57  |  batch_loss: 4.1129  |  lr: 3.10e-05  |
|  step: 4  |  epoch: 0  |  batch_num: 40  |  batch_dt: 919.49  |  batch_loss: 3.9937  |  lr: 4.10e-05  |
```